### PR TITLE
Allow both context and errors to be passed together

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ This transport respects several options:
 You will need to configure Honeybadger through environment variables or the configuration option
 documented above. See [Honeybadger]'s setup instructions for more information.
 
+## Log Handling
+
+Since Honeybadger operates around error messages, you can pass error objects into your log in one
+of three ways:
+
+```js
+const err = new Error('Something bad happened');
+
+// As the first argument:
+winston.error(err);
+// As the second argument:
+winston.error('Problem in plumbus', err);
+// As `error` in an object in the second argument (the rest of the object will be sent to Honeybadger as context):
+winston.error('Problem in reactor', { radiationLevel: 12, error: err });
+```
+
 # Contributing
 
 Pull requests are welcome. Code style is inherited from [airbnb-base](https://www.npmjs.com/package/eslint-config-airbnb-base)

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -1,5 +1,6 @@
 import winston from 'winston';
 import hb from 'honeybadger';
+import isPlainObject from 'lodash.isplainobject';
 
 class Honeybadger extends winston.Transport {
   name = 'honeybadger';
@@ -23,6 +24,13 @@ class Honeybadger extends winston.Transport {
       message = context;
       metadata.context = {
         logMessage: winstonMessage,
+      };
+    } else if (isPlainObject(context) && context.error instanceof Error) {
+      const { error, ...rest } = context;
+      message = error;
+      metadata.context = {
+        logMessage: winstonMessage,
+        ...rest,
       };
     } else {
       message = winstonMessage;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "honeybadger": "^1.2.0",
+    "lodash.isplainobject": "^4.0.6",
     "winston": "^2.2.0"
   }
 }

--- a/test/transport.spec.js
+++ b/test/transport.spec.js
@@ -51,12 +51,40 @@ describe('honeybadger transport', () => {
       });
     });
 
-    it('should handle errors specially', (done) => {
+    it('should accept error messages and context objects', (done) => {
+      const error = new Error('Critical core malfunction');
+      const context = { reactor: 2, rads: 450 };
+      transport.log('info', error, context, (err, { errorOrMessage, metadata }) => {
+        expect(errorOrMessage).to.eql(error);
+        expect(metadata.context).to.eql(context);
+        done();
+      });
+    });
+
+    it('should handle error context specially', (done) => {
       const message = 'Error processing fruits';
       const error = new Error('Something bad happened');
       transport.log('info', message, error, (err, { errorOrMessage, metadata }) => {
         expect(errorOrMessage).to.eql(error);
         expect(metadata.context).to.eql({ logMessage: message });
+        done();
+      });
+    });
+
+    it('should search `context` for an error object', (done) => {
+      const message = 'Error processing vegetables';
+      const context = {
+        error: new Error('Seeds detected'),
+        target: 'tomato',
+        count: 7,
+      };
+      transport.log('info', message, context, (err, { errorOrMessage, metadata }) => {
+        expect(errorOrMessage).to.eql(context.error);
+        expect(metadata.context).to.eql({
+          logMessage: message,
+          target: context.target,
+          count: context.count,
+        });
         done();
       });
     });


### PR DESCRIPTION
Right now if you want to include a message, context *and* an error object with your logs, Honeybadger doesn't get any special insights into the error object.

This introduces a special context structure such that:

```js
const err = new Error('Gravity malfunction');
winston.error('Something very bad happened', { error: err, gAcc: 9.7 });
```